### PR TITLE
Detect all possible specifications of pypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-This Vim plug-in will set the filetype to python for files which start with
-any of the following lines:
+This Vim plug-in will set the filetype to python for files which start
+with any of the following lines:
 
     #!/usr/bin/env pypy
     #!/usr/bin/env pypy3

--- a/README.md
+++ b/README.md
@@ -2,14 +2,29 @@
 
 ## Introduction
 
-This Vim plug-in will set the filetype for the files start with following line:
+This Vim plug-in will set the filetype to python for files which start
+with any of the following lines:
 
     #!/usr/bin/env pypy
+    #!/usr/bin/env pypy3
+    #!/usr/bin/pypy
+    #!/usr/bin/pypy3
+    #!/usr/local/bin/env pypy
+    #!/usr/local/bin/env pypy3
+    #!/usr/local/bin/pypy
+    #!/usr/local/bin/pypy3
 
+In fact, any path that ends with any of `<..>/bin/env pypy`, `<..>/bin/env pypy3`,
+`<..>/bin/pypy`, `<..>/bin/pypy3`, will be detected.
 
 ## Installation
 
-If you are using [Vundle](https://github.com/VundleVim/Vundle.vim), you can
-install this Vim plug-in by adding following line:
+If you are using [Vundle](https://github.com/VundleVim/Vundle.vim), you
+can install this plug-in by adding following line:
 
     Plugin 'loganchien/pypy-shebang-ftdect'
+
+If you are using [vim-plug](https://github.com/junegunn/vim-plug), you
+can install this plug-in by adding following line:
+
+    Plug 'loganchien/pypy-shebang-ftdect'

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ In fact, any path that ends with any of `<..>/bin/env pypy`, `<..>/bin/env pypy3
 If you are using [Vundle](https://github.com/VundleVim/Vundle.vim), you
 can install this plug-in by adding following line:
 
-    Plugin 'loganchien/pypy-shebang-ftdect'
+    Plugin 'bulletmark/pypy-shebang-ftdect'
 
 If you are using [vim-plug](https://github.com/junegunn/vim-plug), you
 can install this plug-in by adding following line:
 
-    Plug 'loganchien/pypy-shebang-ftdect'
+    Plug 'bulletmark/pypy-shebang-ftdect'

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-This Vim plug-in will set the filetype for files which start with any of
-the following lines:
+This Vim plug-in will set the filetype to python for files which start with
+any of the following lines:
 
     #!/usr/bin/env pypy
     #!/usr/bin/env pypy3

--- a/README.md
+++ b/README.md
@@ -2,14 +2,29 @@
 
 ## Introduction
 
-This Vim plug-in will set the filetype for the files start with following line:
+This Vim plug-in will set the filetype for files which start with any of
+the following lines:
 
     #!/usr/bin/env pypy
+    #!/usr/bin/env pypy3
+    #!/usr/bin/pypy
+    #!/usr/bin/pypy3
+    #!/usr/local/bin/env pypy
+    #!/usr/local/bin/env pypy3
+    #!/usr/local/bin/pypy
+    #!/usr/local/bin/pypy3
 
+In fact, any path that ends with any of `<..>/bin/env pypy`, `<..>/bin/env pypy3`,
+`<..>/bin/pypy`, `<..>/bin/pypy3`, will be detected.
 
 ## Installation
 
-If you are using [Vundle](https://github.com/VundleVim/Vundle.vim), you can
-install this Vim plug-in by adding following line:
+If you are using [Vundle](https://github.com/VundleVim/Vundle.vim), you
+can install this plug-in by adding following line:
 
     Plugin 'loganchien/pypy-shebang-ftdect'
+
+If you are using [vim-plug](https://github.com/junegunn/vim-plug), you
+can install this plug-in by adding following line:
+
+    Plug 'loganchien/pypy-shebang-ftdect'

--- a/ftdetect/pypy.vim
+++ b/ftdetect/pypy.vim
@@ -4,7 +4,7 @@ function DetectPyPyFile()
     endif
 
     " If the file starts with PyPy shebang line, then set filetype.
-    if getline(1) =~ '^#!.*/usr/bin/env\s\+\<pypy\>'
+    if getline(1) =~ '^#!.*/bin/\(env\s\+\)\?\<pypy3\?\>'
         setfiletype python
     endif
 endfunction


### PR DESCRIPTION
This PR adds many more (all?) combinations of how `pypy` can be specified in the shebang line. Refer the updated [README](https://github.com/bulletmark/pypy-shebang-ftdetect/tree/add-pypy3).